### PR TITLE
now deleting tiles as they are removed from the layout

### DIFF
--- a/QTileLayout/tileLayout.py
+++ b/QTileLayout/tileLayout.py
@@ -287,6 +287,7 @@ class QTileLayout(QtWidgets.QGridLayout):
 
         for tile in tilesToRecycle:
             super().removeWidget(tile)
+            tile.deleteLater()
 
         tile = self.tileMap[fromRow][fromColumn]
         super().addWidget(tile, fromRow, fromColumn)
@@ -346,6 +347,7 @@ class QTileLayout(QtWidgets.QGridLayout):
         """merges the tilesToMerge with tile"""
         for row, column in tilesToMerge:
             super().removeWidget(self.tileMap[row][column])
+            self.tileMap[row][column].deleteLater()
             self.tileMap[row][column] = tile
 
         super().removeWidget(tile)

--- a/QTileLayout/tileLayout.py
+++ b/QTileLayout/tileLayout.py
@@ -128,7 +128,7 @@ class QTileLayout(QtWidgets.QGridLayout):
         for row in range(self.rowNumber - rowNumber, self.rowNumber):
             for column in range(self.columnNumber):
                 super().removeWidget(self.tileMap[row][column])
-
+                self.tileMap[row][column].deleteLater()
             self.setRowMinimumHeight(row, 0)
             self.setRowStretch(row, 0)
 
@@ -142,6 +142,7 @@ class QTileLayout(QtWidgets.QGridLayout):
         for column in range(self.columnNumber - columnNumber, self.columnNumber):
             for row in range(self.rowNumber):
                 super().removeWidget(self.tileMap[row][column])
+                self.tileMap[row][column].deleteLater()
 
             self.setColumnMinimumWidth(column, 0)
             self.setColumnStretch(column, 0)


### PR DESCRIPTION
Works well with PyQt 5.12.2 at least.

This fixes parentless tiles floating are resizing or moving tiles with rowSpan or columnSpan larger than 1.