### PR TITLE
clearing the focus of the widget that is about to be removed eliminate…

### DIFF
--- a/QTileLayout/tile.py
+++ b/QTileLayout/tile.py
@@ -205,6 +205,7 @@ class Tile(QtWidgets.QWidget):
         previousColumnSpan = self.columnSpan
 
         self.tileLayout.setWidgetToDrop(self.widget)
+        self.widget.clearFocus()
         self.tileLayout.removeWidget(self.widget)
         self.setVisible(False)
         self.tileLayout.changeTilesColor('drag_and_drop')


### PR DESCRIPTION
…s the call to focusNextChild in the layout backend. This removes the issue of random scrolling in a scroll area because focus widgets are ensured visible.