### PR TITLE
Mouse press event should not trigger drag

### DIFF
--- a/QTileLayout/tile.py
+++ b/QTileLayout/tile.py
@@ -85,30 +85,31 @@ class Tile(QtWidgets.QWidget):
         print('event', event)
         if event.buttons() == Qt.LeftButton:
             # adjust offset from clicked point to origin of widget
-            globalPos = event.globalPos()
-            lastpos = self.mapToGlobal(self.__mouseMovePos)
-            diff = globalPos - lastpos  # calculate the difference when moving the mouse
-            if diff.manhattanLength() > 3:
-                if self.lock is None and not self.drag_in_process:
-                    if event.pos().x() < self.resizeMargin and self.tileLayout.resizable:
-                        self.lock = (-1, 0)  # 'west'
-                    elif event.pos().x() > self.width() - self.resizeMargin and self.tileLayout.resizable:
-                        self.lock = (1, 0)  # 'east'
-                    elif event.pos().y() < self.resizeMargin and self.tileLayout.resizable:
-                        self.lock = (0, -1)  # 'north'
-                    elif event.pos().y() > self.height() - self.resizeMargin and self.tileLayout.resizable:
-                        self.lock = (0, 1)  # 'south'
+            if self.__mouseMovePos:
+                globalPos = event.globalPos()
+                lastpos = self.mapToGlobal(self.__mouseMovePos)
+                diff = globalPos - lastpos  # calculate the difference when moving the mouse
+                if diff.manhattanLength() > 3:
+                    if self.lock is None and not self.drag_in_process:
+                        if event.pos().x() < self.resizeMargin and self.tileLayout.resizable:
+                            self.lock = (-1, 0)  # 'west'
+                        elif event.pos().x() > self.width() - self.resizeMargin and self.tileLayout.resizable:
+                            self.lock = (1, 0)  # 'east'
+                        elif event.pos().y() < self.resizeMargin and self.tileLayout.resizable:
+                            self.lock = (0, -1)  # 'north'
+                        elif event.pos().y() > self.height() - self.resizeMargin and self.tileLayout.resizable:
+                            self.lock = (0, 1)  # 'south'
 
-                    if self.lock is not None:
-                        self.tileLayout.changeTilesColor('resize')
+                        if self.lock is not None:
+                            self.tileLayout.changeTilesColor('resize')
 
-                    elif self.filled and self.tileLayout.dragAndDrop:
-                        drag = self.__prepareDropData(event)
-                        self.__dragAndDropProcess(drag)
-                        self.tileLayout.changeTilesColor('idle')
+                        elif self.filled and self.tileLayout.dragAndDrop:
+                            drag = self.__prepareDropData(event)
+                            self.__dragAndDropProcess(drag)
+                            self.tileLayout.changeTilesColor('idle')
 
-                    if self.filled:
-                        self.widget.setFocus()
+                        if self.filled:
+                            self.widget.setFocus()
         if not self.filled:
             self.setCursor(QtGui.QCursor(self.tileLayout.cursorIdle))
 

--- a/QTileLayout/tile.py
+++ b/QTileLayout/tile.py
@@ -82,7 +82,6 @@ class Tile(QtWidgets.QWidget):
 
     def mouseMoveEvent(self, event):
         """actions to do when the mouse is moved"""
-        print('event', event)
         if event.buttons() == Qt.LeftButton:
             # adjust offset from clicked point to origin of widget
             if self.__mouseMovePos:
@@ -90,26 +89,16 @@ class Tile(QtWidgets.QWidget):
                 lastpos = self.mapToGlobal(self.__mouseMovePos)
                 diff = globalPos - lastpos  # calculate the difference when moving the mouse
                 if diff.manhattanLength() > 3:
-                    if self.lock is None and not self.drag_in_process:
-                        if event.pos().x() < self.resizeMargin and self.tileLayout.resizable:
-                            self.lock = (-1, 0)  # 'west'
-                        elif event.pos().x() > self.width() - self.resizeMargin and self.tileLayout.resizable:
-                            self.lock = (1, 0)  # 'east'
-                        elif event.pos().y() < self.resizeMargin and self.tileLayout.resizable:
-                            self.lock = (0, -1)  # 'north'
-                        elif event.pos().y() > self.height() - self.resizeMargin and self.tileLayout.resizable:
-                            self.lock = (0, 1)  # 'south'
+                    if not self.drag_in_process and self.lock is None:
 
-                        if self.lock is not None:
-                            self.tileLayout.changeTilesColor('resize')
-
-                        elif self.filled and self.tileLayout.dragAndDrop:
+                        if self.filled and self.tileLayout.dragAndDrop:
                             drag = self.__prepareDropData(event)
                             self.__dragAndDropProcess(drag)
                             self.tileLayout.changeTilesColor('idle')
 
                         if self.filled:
                             self.widget.setFocus()
+
         if not self.filled:
             self.setCursor(QtGui.QCursor(self.tileLayout.cursorIdle))
 
@@ -145,16 +134,26 @@ class Tile(QtWidgets.QWidget):
 
     def mousePressEvent(self, event):
         """actions to do when the mouse button is pressed"""
-        if event.button() != Qt.LeftButton:
+        if event.button() == Qt.LeftButton:
+            self.__mouseMovePos = event.pos()
+            if event.pos().x() < self.resizeMargin and self.tileLayout.resizable:
+                self.lock = (-1, 0)  # 'west'
+            elif event.pos().x() > self.width() - self.resizeMargin and self.tileLayout.resizable:
+                self.lock = (1, 0)  # 'east'
+            elif event.pos().y() < self.resizeMargin and self.tileLayout.resizable:
+                self.lock = (0, -1)  # 'north'
+            elif event.pos().y() > self.height() - self.resizeMargin and self.tileLayout.resizable:
+                self.lock = (0, 1)  # 'south'
+            if self.lock is not None:
+                self.tileLayout.changeTilesColor('resize')
+        else:
             self.__mouseMovePos = None
-            return super().mousePressEvent(event)
-        self.__mouseMovePos = event.pos()
         super().mousePressEvent(event)
 
     def mouseReleaseEvent(self, event):
         """actions to do when the mouse button is released"""
         if self.lock is None:
-            return super().mouseReleaseEvent(event)
+            super().mouseReleaseEvent(event)
 
         x, y = event.pos().x(), event.pos().y()
         tileNumber = self.__getResizeTileNumber(x, y)

--- a/QTileLayout/tileLayout.py
+++ b/QTileLayout/tileLayout.py
@@ -32,6 +32,7 @@ class QTileLayout(QtWidgets.QGridLayout):
         # logic parameters
         self.dragAndDrop = True
         self.resizable = True
+        self.focus = False
         self.widgetToDrop = None
         self.tileMap = []
         self.widgetTileCouple = {'widget': [], 'tile': []}
@@ -249,6 +250,10 @@ class QTileLayout(QtWidgets.QGridLayout):
         """Sets the horizontal spacing between two tiles"""
         super().setHorizontalSpacing(spacing)
         self.__updateAllTiles()
+
+    def activateFocus(self, focus: bool):
+        """activates or not the widget focus after drag & drop or resize"""
+        self.focus = focus
 
     def widgetList(self) -> list:
         """Returns the widgets currently in the layout"""

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ _Allows or not the drag and drop of tiles in the layout_
 _Allows or not the resizing of tiles in the layout_  
 &nbsp;
 
+- ```activateFocus(bool focus)```
+
+_Activates or not the widget focus after drag & drop or resize. This feature can lead to unexpected behaviours in some cases, please set focus on false if you notice any of them_  
+&nbsp;
+
 - ```addcolumns(int columnNumber)```
 
 _Adds columns at the right of the layout_  

--- a/test.py
+++ b/test.py
@@ -37,12 +37,15 @@ class Label(QtWidgets.QLabel):
 
     def focusInEvent(self, event):
         print("WIDGET FOCUS IN EVENT", self)
+        super().focusInEvent(event)
 
     def focusOutEvent(self, event):
         print("WIDGET FOCUS OUT EVENT", self)
+        super().focusOutEvent(event)
 
     def keyPressEvent(self, ev: QtGui.QKeyEvent):
         print("WIDGET KEY PRESSED", self)
+        super().keyPressEvent(ev)
 
 
 class MainWindow(QtWidgets.QMainWindow):

--- a/test.py
+++ b/test.py
@@ -156,6 +156,9 @@ class MainWindow(QtWidgets.QMainWindow):
         # set the tiles width
         self.tile_layout.setColumnsWidth(150)
 
+        # set the focus on widget after drag & drop or resize
+        self.tile_layout.activateFocus(False)
+
         # actions to do when a tile is resized
         self.tile_layout.tileResized.connect(self.__tileHasBeenResized)
         # actions to do when a tile is moved


### PR DESCRIPTION
For some reason this does not work in test.py

When i drag or resize a widget, it's like the events are no longer received on the widget after that and the cursor stays the same when hovering that widget.

The funny thing is that it works in my application. And i have my normal behavior when im pressing the widgets just to select or double click them.

Maybe you have another application you can test it with, and/or find the issue?